### PR TITLE
Fix incorrect RepositoryUrl in new packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,7 @@ jobs:
     if: github.event_name == 'release'
     environment:
       name: "NuGet"
-      url: https://www.nuget.org/packages/NuGetTemplate
+      url: https://www.nuget.org
     runs-on: ubuntu-latest
     steps:
       - name: "Download Artifact"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           name: "ubuntu-latest"
       - name: "Dotnet NuGet Add Source"
-        run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler-api/index.json --name GitHub --username web-scheduler-api --password ${{secrets.GITHUB_TOKEN}}
+        run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler/web-scheduler-api/index.json --name GitHub --username web-scheduler-api --password ${{secrets.GITHUB_TOKEN}}
         shell: pwsh
       - name: "Dotnet NuGet Push"
         run: dotnet nuget push .\**\*.nupkg --api-key ${{ github.token }} --source GitHub --skip-duplicate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           name: "ubuntu-latest"
       - name: "Dotnet NuGet Add Source"
-        run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler/web-scheduler-api/index.json --name GitHub --username web-scheduler-api --password ${{secrets.GITHUB_TOKEN}}
+        run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler-api/index.json --name GitHub --username web-scheduler-api --password ${{secrets.GITHUB_TOKEN}}
         shell: pwsh
       - name: "Dotnet NuGet Push"
         run: dotnet nuget push .\**\*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source GitHub --skip-duplicate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
         run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler/web-scheduler-api/index.json --name GitHub --username web-scheduler-api --password ${{secrets.GITHUB_TOKEN}}
         shell: pwsh
       - name: "Dotnet NuGet Push"
-        run: dotnet nuget push .\**\*.nupkg --api-key ${{ github.token }} --source GitHub --skip-duplicate
+        run: dotnet nuget push .\**\*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source GitHub --skip-duplicate
         shell: pwsh
 
   push-nuget:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           name: "ubuntu-latest"
       - name: "Dotnet NuGet Add Source"
-        run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler-api/index.json --name GitHub --username web-scheduler --password ${{secrets.GITHUB_TOKEN}}
+        run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler-api/index.json --name GitHub --username web-scheduler-api --password ${{secrets.GITHUB_TOKEN}}
         shell: pwsh
       - name: "Dotnet NuGet Push"
         run: dotnet nuget push .\**\*.nupkg --api-key ${{ github.token }} --source GitHub --skip-duplicate

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
         run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler-api/index.json --name GitHub --username web-scheduler-api --password ${{secrets.GITHUB_TOKEN}}
         shell: pwsh
       - name: "Dotnet NuGet Push"
-        run: dotnet nuget push .\**\*.nupkg --api-key ${{ secrets.GITHUB_TOKEN }} --source GitHub --skip-duplicate
+        run: dotnet nuget push .\**\*.nupkg --api-key ${{ github.token }} --source GitHub --skip-duplicate
         shell: pwsh
 
   push-nuget:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,7 +130,7 @@ jobs:
         with:
           name: "ubuntu-latest"
       - name: "Dotnet NuGet Add Source"
-        run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler-api/index.json --name GitHub --username web-scheduler-api --password ${{secrets.GITHUB_TOKEN}}
+        run: dotnet nuget add source https://nuget.pkg.github.com/web-scheduler-api/index.json --name GitHub --username web-scheduler --password ${{secrets.GITHUB_TOKEN}}
         shell: pwsh
       - name: "Dotnet NuGet Push"
         run: dotnet nuget push .\**\*.nupkg --api-key ${{ github.token }} --source GitHub --skip-duplicate

--- a/Source/WebScheduler.Client.Core/WebScheduler.Client.Core.csproj
+++ b/Source/WebScheduler.Client.Core/WebScheduler.Client.Core.csproj
@@ -21,7 +21,7 @@
     <RepositoryUrl>https://github.com/web-scheduler/web-scheduler-api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://github.com/web-scheduler/web-scheduler-api</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/web-scheduler/web-scheduler/releases-api</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/web-scheduler/web-scheduler-api/releases</PackageReleaseNotes>
 
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Source/WebScheduler.Client.Core/WebScheduler.Client.Core.csproj
+++ b/Source/WebScheduler.Client.Core/WebScheduler.Client.Core.csproj
@@ -18,10 +18,10 @@
     <IsTrimmable>false</IsTrimmable>
     <Sign>false</Sign>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <RepositoryUrl>https://github.com/web-scheduler/web-scheduler</RepositoryUrl>
+    <RepositoryUrl>https://github.com/web-scheduler/web-scheduler-api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>https://github.com/web-scheduler/web-scheduler</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/web-scheduler/web-scheduler/releases</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/web-scheduler/web-scheduler-api</PackageProjectUrl>
+    <PackageReleaseNotes>https://github.com/web-scheduler/web-scheduler/releases-api</PackageReleaseNotes>
 
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>

--- a/Source/WebScheduler.Client.Http/WebScheduler.Client.Http.csproj
+++ b/Source/WebScheduler.Client.Http/WebScheduler.Client.Http.csproj
@@ -18,10 +18,10 @@
     <IsTrimmable>false</IsTrimmable>
     <Sign>false</Sign>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <RepositoryUrl>https://github.com/web-scheduler/web-scheduler</RepositoryUrl>
+    <RepositoryUrl>https://github.com/web-scheduler/web-scheduler-api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>https://github.com/web-scheduler/web-scheduler</PackageProjectUrl>
-    <PackageReleaseNotes>https://github.com/web-scheduler/web-scheduler/releases</PackageReleaseNotes>
+    <PackageProjectUrl>https://github.com/web-scheduler/web-scheduler-api</PackageProjectUrl>
+    <PackageReleaseNotes>https://github.com/web-scheduler/web-scheduler-api/releases</PackageReleaseNotes>
 
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>


### PR DESCRIPTION
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-nuget-registry#publishing-multiple-packages-to-the-same-repository:~:text=GitHub%20matches%20the%20repository%20based%20on%20that%20field


> To publish multiple packages to the same repository, you can include the same GitHub repository URL in the RepositoryURL fields in all .csproj project files. GitHub matches the repository based on that field.