### PR TITLE
Register `IClusterClient`.

### DIFF
--- a/Source/WebScheduler.Client.Http/ProjectServiceCollectionExtensions.cs
+++ b/Source/WebScheduler.Client.Http/ProjectServiceCollectionExtensions.cs
@@ -26,7 +26,7 @@ public static class ProjectServiceCollectionExtensions
     public static IServiceCollection AddWebSchedulerHttpClient(this IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration) =>
         services
             .AddWebScheduler(configuration)
-            .AddProjectCommands();
+            .AddProjectCommands(addClusterClient: true);
 
     internal static IServiceCollection AddProjectCommands(this IServiceCollection services) =>
         services

--- a/Source/WebScheduler.Client.Http/ProjectServiceCollectionExtensions.cs
+++ b/Source/WebScheduler.Client.Http/ProjectServiceCollectionExtensions.cs
@@ -25,8 +25,8 @@ public static class ProjectServiceCollectionExtensions
     /// <returns>A reference to this instance after the operation has completed.</returns>
     public static IServiceCollection AddWebSchedulerHttpClient(this IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration) =>
         services
-            .AddWebScheduler(configuration)
-            .AddProjectCommands(addClusterClient: true);
+            .AddWebScheduler(configuration, addClusterClient: true)
+            .AddProjectCommands();
 
     internal static IServiceCollection AddProjectCommands(this IServiceCollection services) =>
         services


### PR DESCRIPTION
A regression was introduced in #244, which by default doesn't register `IClusterClient`. 

The Api host will now register it.